### PR TITLE
Remove name tag and add application name to the serviceName.

### DIFF
--- a/lib/components/jaeger.js
+++ b/lib/components/jaeger.js
@@ -29,8 +29,7 @@ module.exports = function(app, opts) {
 var Component = function(app, opts) {
   if(opts) {
     opts.tags = opts.tags || {};
-    opts.tags['game'] = app.get('name');
-    opts.serviceName = app.serverType;
+    opts.serviceName = app.get('name') + "-" + app.serverType;
 
     jaeger.configure(opts);
   }


### PR DESCRIPTION
When building the Jaeger dependency graph, all services of the same type are mixed. 
This PR solve the problem.