### PR TITLE
Update jaeger-tracer-node and pomelo-rpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomelo",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "private": false,
   "homepage": "https://github.com/NetEase/pomelo",
   "repository": {
@@ -33,7 +33,7 @@
     "commander": "2.0.0",
     "crc": "0.2.0",
     "ioredis": "1.10.0",
-    "jaeger-tracer-node": "topfreegames/jaeger-tracer-node#v1.3.1",
+    "jaeger-tracer-node": "topfreegames/jaeger-tracer-node#v1.3.7",
     "mkdirp": "0.3.3",
     "mqtt": "0.3.9",
     "node-bignumber": "1.2.1",
@@ -43,7 +43,7 @@
     "pomelo-logger": "topfreegames/pomelo-logger#0.1.9",
     "pomelo-protobuf": "0.4.0",
     "pomelo-protocol": "0.1.6",
-    "pomelo-rpc": "topfreegames/pomelo-rpc#1.4.1-tracing",
+    "pomelo-rpc": "topfreegames/pomelo-rpc#1.4.2-tracing",
     "pomelo-scheduler": "topfreegames/pomelo-scheduler#new-pomelo-logger",
     "redis": "0.12.1",
     "seq-queue": "0.0.5",


### PR DESCRIPTION
This update depends on another pull request for pomelo-rpc (1.4.2-tracing).